### PR TITLE
Updated Stemettes link in resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
                     <a href="https://modelviewculture.com/support">Model View Culture</a>,
                     <a href="https://www.alterconf.com/sponsor">AlterConf</a>,
                     <a href="https://donate.codebar.io/">Codebar</a> and
-                    <a href="http://stemettes.org/sponsors">Stemettes</a>.
+                    <a href="http://stemettes.org/partners">Stemettes</a>.
                 </p>
                 <p>
                     Want to extend or change this pledge? This whole site is fully open-source,


### PR DESCRIPTION
Was pointing to /sponsors which is 404, correct page appears to be /partners.